### PR TITLE
Increase header logo size

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -151,14 +151,14 @@ header nav[aria-expanded='true'] .nav-hamburger-icon::after {
 /* brand */
 header .nav-brand {
   grid-area: brand;
-  flex-basis: 128px;
+  flex-basis: 180px;
   font-size: var(--heading-font-size-s);
   font-weight: 700;
   line-height: 1;
 }
 
 header nav .nav-brand img {
-  width: 100px;
+  width: 150px;
   height: auto;
 }
 


### PR DESCRIPTION
- Updated logo image width from 100px to 150px
- Increased nav-brand container flex-basis from 128px to 180px to accommodate larger logo
- Maintains proper aspect ratio with height: auto